### PR TITLE
Update client.py ajout erreur si partie finie, et limitation des requetes end() au serveur

### DIFF
--- a/2017/client.py
+++ b/2017/client.py
@@ -1,4 +1,5 @@
 import socket
+import time
 
 class Reseau:
 	'''
@@ -41,6 +42,8 @@ class Reseau:
 	def __init__(self, host="matthieu-zimmer.net", port=23456):
 		self.connect = False
 		self.topbool = False
+		self.timerInitial = 0
+		self.tempsPartie= 0
 		self.sock=socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 		self.sock.settimeout(5)
 		result = self.sock.connect_ex((host, port))
@@ -57,6 +60,10 @@ class Reseau:
 	def __estTop(self):
 		if(not self.topbool):
 			raise RuntimeError("La partie n'est pas encore commencee.")
+	
+	def __notEnd(self):#verifie si la partie n'est pas finie
+		if(self.fin()['temps']<=0): 
+			raise RuntimeError("La partie est finie.")
 	
 	def __envoyer(self, commande):
 		try:
@@ -125,6 +132,9 @@ class Reseau:
 		self.__envoyer("TOP")
 		r = int(self.__recevoir())
 		self.topbool= True
+		self.__envoyer("FIN") #Pour avoir la duree de la partie
+		self.dureePartie=int(eval(self.__recevoir())['temps'])
+		self.timerInitial=time.time() #lance le 'chronometre' quand le serveur a lance le top
 		return r
 
 	def solde(self):
@@ -132,6 +142,7 @@ class Reseau:
 		Retourne un dictionnaire (string:entier) avec vos actions et vos euros.
 		'''
 		self.__estTop()
+		self.__notEnd()
 		self.__envoyer("SOLDE")
 		return eval(self.__recevoir())
 	
@@ -142,6 +153,7 @@ class Reseau:
 		Cela permet de pouvoir les suivre ou les annuler.
 		'''
 		self.__estTop()
+		self.__notEnd()
 		self.__envoyer("OPERATIONS")
 		return eval(self.__recevoir())
 
@@ -164,6 +176,7 @@ class Reseau:
 		@type volume: entier
 		'''
 		self.__estTop()
+		self.__notEnd()
 		self.__envoyer("ASK "+action+" "+str(prix)+" "+str(volume))
 		return eval(self.__recevoir())
 
@@ -186,6 +199,7 @@ class Reseau:
 		@type volume: entier
 		'''
 		self.__estTop()
+		self.__notEnd()
 		self.__envoyer("BID "+action+" "+str(prix)+" "+str(volume))
 		return eval(self.__recevoir())
 
@@ -199,6 +213,7 @@ class Reseau:
 		@type action: string
 		'''
 		self.__estTop()
+		self.__notEnd()
 		self.__envoyer("ACHATS "+action)
 		return eval(self.__recevoir())
 	
@@ -212,6 +227,7 @@ class Reseau:
 		@type action: string
 		'''
 		self.__estTop()
+		self.__notEnd()
 		self.__envoyer("VENTES "+action)
 		return eval(self.__recevoir())
 
@@ -224,6 +240,7 @@ class Reseau:
 		@type action: string
 		'''
 		self.__estTop()
+		self.__notEnd()
 		self.__envoyer("HISTO "+action)
 		return eval(self.__recevoir())
 
@@ -239,6 +256,7 @@ class Reseau:
 		@type id_ordre: entier
 		'''
 		self.__estTop()
+		self.__notEnd()
 		self.__envoyer("SUIVRE "+str(id_ordre))
 		return eval(self.__recevoir())
 
@@ -255,6 +273,7 @@ class Reseau:
 		@type id_ordre: entier
 		'''
 		self.__estTop()
+		self.__notEnd()
 		self.__envoyer("ANNULER "+str(id_ordre))
 		return eval(self.__recevoir())
 
@@ -264,7 +283,13 @@ class Reseau:
 		
 		Lorsque la partie est terminee, un classement des joueurs est ajoute dans le dictionnaire (string:liste).
 		'''
+
+			
 		self.__estTop()
-		self.__envoyer("FIN")
-		return eval(self.__recevoir())
+		tempsRestant=self.tempsPartie + self.timerInitial - time.time() #tempsPartie-(TempsAct-TempsInitial)
+		if(tempsRestant>0): #Dans ce cas, pas besoin de faire une requête au serveur, on affiche simplement le temps restant
+			return {'temps': tempsRestant}
+		else:#si la partie est finie on fait une requete au serveur pour qu'il donne la liste des vainqueurs
+			self.__envoyer("FIN")
+			return eval(self.__recevoir())
 


### PR DESCRIPTION
J'ai ajouté un code d'erreur dans le cas où un client fait une requète de bourse alors que la partie est finie (notEnd)
Cependant ce code d'erreur fait un appel à fin() à chaque requète de bourse donc celà doublerait le nombre de requète au serveur pendant une partie (risque de problèmes s'il y a trop de requète au serveur).
C'est pour celà que j'ai instauré un compteur de temps local au client, afin que fin() ne fasse plus de requète au serveur, mais retourne simplement la valeur du compteur local tant que la partie n'est pas finie
Les deux erreurs possibles de désynchronisation des timers entre client/serveur ne posent pas de problème:
Si le client est en avance, alors son timer finira avant celui du serveur et donc il y aura des requètes au serveur pendant les dernières millisecondes de la partie qui renverra le temps réel.
Si le client est en retard, le client fera des requètes au serveur que le serveur rejettera car la partie est finie.